### PR TITLE
Listing large buckets completely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ FROM openjdk:8
 EXPOSE 8080
 
 WORKDIR /usr/src/app
-COPY build/libs/ecs-browser-1.0.0rc1.jar ./
+COPY build/libs/ecs-browser-1.0.0rc2.jar ./
 
-CMD [ "java", "-jar", "ecs-browser-1.0.0rc1.jar" ]
+CMD [ "java", "-jar", "ecs-browser-1.0.0rc2.jar" ]

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 description = "ECS browser website"
 group = 'com.emc.ecs'
-version = '1.0.0rc1'
+version = '1.0.0rc2'
 
 ext.licenseName = ''
 ext.licenseUrl = ''
@@ -30,7 +30,7 @@ defaultTasks 'build'
 
 jar {
     baseName = 'ecs-browser'
-    version =  '1.0.0rc1'
+    version =  '1.0.0rc2'
     into('META-INF/dependency-license') {
         from 'build/reports/dependency-license'
     }

--- a/src/main/resources/static/javascript/ecs-sdk.js
+++ b/src/main/resources/static/javascript/ecs-sdk.js
@@ -226,6 +226,7 @@ EcsS3.prototype.listBuckets = function( callback ) {
 
 EcsS3.prototype.listObjects = function( params, callback ) {
     var apiUrl = this.getBucketApiUrl( params.entry );
+    var headers = this.getHeaders('GET');
     var separatorChar = '?';
     if ( isNonEmptyString( params.delimiter ) ) {
       apiUrl = apiUrl + separatorChar + 'delimiter=' + params.delimiter;
@@ -238,9 +239,10 @@ EcsS3.prototype.listObjects = function( params, callback ) {
     if ( isNonEmptyString( params.extraQueryParameters ) ) {
       apiUrl = apiUrl + separatorChar + params.extraQueryParameters;
       separatorChar = '&';
+    } else {
+      headers['X-Passthrough-Type'] = 'listAll';
     }
-    var headers = this.getHeaders('GET');
-    
+
     $.ajax({ url: apiUrl,  method: 'POST', headers: headers,
         success: function(data, textStatus, jqHXR) {
             handleData( data, callback, getEcsBody );


### PR DESCRIPTION
The browser now lists all objects in buckets and folders of arbitrary size. This currently works only for simple object lists, and not for version lists, metadata searches or bucket lists.